### PR TITLE
chore: check for termux playstore version before install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,12 @@
 DIE() { echo -e "${@}"; exit 1 ;:;}
 GWARN() { echo -e "\e[90m${*}\e[0m";:;}
 
+# Check for termux playstore version:
+if [[ "$TERMUX_VERSION" == "googleplay"* ]]; then
+  GWARN "Termux Play Store version detected."
+  DIE "The Play Store version is unsupported.\nPlease reinstall Termux from F-Droid: https://f-droid.org/packages/com.termux/"
+fi
+
 apt install -y jq wget proot pv pulseaudio libandroid-shmem-static which
 [[ ! -d udroid/src ]] && {
     echo "udroid/src not found"


### PR DESCRIPTION
Observed people trying udroid from the Play Store. Currently, currently udroid wont support playstore, this PR adds a check to detect the Termux Play Store version and cancels the install.


closes https://github.com/RandomCoderOrg/fs-manager-udroid/issues/54

- https://github.com/orgs/RandomCoderOrg/discussions/261#discussioncomment-16399785